### PR TITLE
fix: expose discord_username dans les endpoints users

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -3,49 +3,51 @@
 namespace App\Http\Controllers\Api;
 
 use App\Actions\GetUserBestLapTimes;
+use App\Actions\GetUsersFavoriteBikes;
 use App\Actions\GetUsersParticipationCounts;
 use App\Actions\GetUsersVictoryCounts;
-use App\Actions\GetUsersFavoriteBikes;
-use App\Models\User;
-use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\UserResource;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 
 class UserController extends Controller
 {
-    function index(
+    public function index(
         GetUsersParticipationCounts $participationCounts,
         GetUsersVictoryCounts $victoryCounts,
         GetUsersFavoriteBikes $favoriteBikes,
     ) {
-        $users = User::select('id', 'name', 'discord_id', 'discord_global_name', 'discord_avatar')
+        $users = User::select('id', 'name', 'discord_id', 'discord_global_name', 'discord_username', 'discord_avatar')
             ->orderBy('name')
             ->get();
 
-        $userIds        = $users->pluck('id');
+        $userIds = $users->pluck('id');
         $participations = $participationCounts->handle($userIds);
-        $victories      = $victoryCounts->handle($userIds);
-        $bikes          = $favoriteBikes->handle($userIds);
+        $victories = $victoryCounts->handle($userIds);
+        $bikes = $favoriteBikes->handle($userIds);
 
-        return $users->map(fn($user) => [
-            'id'                  => $user->id,
-            'name'                => $user->name,
-            'discord_id'          => $user->discord_id,
+        return $users->map(fn ($user) => [
+            'id' => $user->id,
+            'name' => $user->name,
+            'discord_id' => $user->discord_id,
             'discord_global_name' => $user->discord_global_name,
-            'discord_avatar'      => $user->discord_avatar,
+            'discord_username' => $user->discord_username,
+            'discord_avatar' => $user->discord_avatar,
             'participation_count' => $participations[$user->id] ?? 0,
-            'victory_count'       => $victories[$user->id] ?? 0,
-            'favorite_bike'       => $bikes[$user->id] ?? null,
+            'victory_count' => $victories[$user->id] ?? 0,
+            'favorite_bike' => $bikes[$user->id] ?? null,
         ]);
     }
 
-    function show(User $user, GetUserBestLapTimes $bestLapTimes, GetUsersVictoryCounts $victoryCounts): UserResource
+    public function show(User $user, GetUserBestLapTimes $bestLapTimes, GetUsersVictoryCounts $victoryCounts): UserResource
     {
         $user->best_lap_times = $bestLapTimes->handle($user);
-        $user->victory_count  = $victoryCounts->handle(collect([$user->id]))[$user->id] ?? 0;
+        $user->victory_count = $victoryCounts->handle(collect([$user->id]))[$user->id] ?? 0;
+
         return new UserResource($user);
     }
 
@@ -54,12 +56,12 @@ class UserController extends Controller
         $user = auth()->user();
 
         $user->best_lap_times = $bestLapTimes->handle($user);
-        $user->victory_count  = $victoryCounts->handle(collect([$user->id]))[$user->id] ?? 0;
+        $user->victory_count = $victoryCounts->handle(collect([$user->id]))[$user->id] ?? 0;
 
         return new UserResource($user);
     }
 
-    function update(Request $request): JsonResponse
+    public function update(Request $request): JsonResponse
     {
         $validator = Validator::make($request->all(), [
             'guid' => 'sometimes|string|unique:users,guid',
@@ -76,7 +78,7 @@ class UserController extends Controller
             ], 422);
         }
 
-        if (!$request->has('guid') && !$request->has('name')) {
+        if (! $request->has('guid') && ! $request->has('name')) {
             return response()->json([
                 'message' => 'No data to update.',
             ], 400);
@@ -84,8 +86,12 @@ class UserController extends Controller
 
         $user = Auth::user();
 
-        if($request->has("guid")) $user->guid = $request->guid;
-        if($request->has("name")) $user->name = $request->name;
+        if ($request->has('guid')) {
+            $user->guid = $request->guid;
+        }
+        if ($request->has('name')) {
+            $user->name = $request->name;
+        }
         $user->save();
 
         return response()->json([
@@ -94,7 +100,7 @@ class UserController extends Controller
         ]);
     }
 
-    function logout(Request $request)
+    public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();
 

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -23,6 +23,7 @@ class UserResource extends JsonResource
             'guid' => $this->guid,
             'discord_id' => $this->discord_id,
             'discord_global_name' => $this->discord_global_name,
+            'discord_username' => $this->discord_username,
             'discord_avatar' => $this->discord_avatar,
             'discord_locale' => $this->discord_locale,
             'created_at' => $this->created_at,
@@ -32,17 +33,17 @@ class UserResource extends JsonResource
             'participation_count' => $bestLapTimes->count(),
             'victory_count' => $this->victory_count ?? 0,
             'best_lap_times_by_track' => $bestLapTimes
-                ->groupBy(fn($lt) => $lt->event->track->id)
-                ->map(fn($group) => $group->sortBy('lap_time')->first())
+                ->groupBy(fn ($lt) => $lt->event->track->id)
+                ->map(fn ($group) => $group->sortBy('lap_time')->first())
                 ->values(),
             'bike_stats_by_category' => $bestLapTimes
-                ->filter(fn($lt) => $lt['bike'] && isset($lt['bike']['category']['name']))
-                ->groupBy(fn($lt) => $lt['bike']['category']['name'])
+                ->filter(fn ($lt) => $lt['bike'] && isset($lt['bike']['category']['name']))
+                ->groupBy(fn ($lt) => $lt['bike']['category']['name'])
                 ->mapWithKeys(function ($group, $categoryName) {
                     return [
                         $categoryName => collect($group)
-                            ->groupBy(fn($lt) => $lt['bike']['name'])
-                            ->map(fn($bikes) => $bikes->count())
+                            ->groupBy(fn ($lt) => $lt['bike']['name'])
+                            ->map(fn ($bikes) => $bikes->count()),
                     ];
                 }),
         ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RoleSeeder::class);
+    }
+
+    private function apiKeyHeader(): array
+    {
+        return ['Authorization' => 'Bearer '.config('custom.api_key')];
+    }
+
+    public function test_index_returns_users_with_discord_username(): void
+    {
+        $user = User::factory()->create(['discord_username' => 'mx_rider']);
+
+        $response = $this->getJson('/api/users', $this->apiKeyHeader());
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'id' => $user->id,
+            'discord_username' => 'mx_rider',
+        ]);
+    }
+
+    public function test_index_requires_api_key(): void
+    {
+        $response = $this->getJson('/api/users');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_show_returns_user_with_discord_username(): void
+    {
+        $user = User::factory()->create(['discord_username' => 'mx_rider']);
+
+        $response = $this->getJson("/api/users/{$user->id}", $this->apiKeyHeader());
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['discord_username' => 'mx_rider']);
+    }
+
+    public function test_show_requires_api_key(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->getJson("/api/users/{$user->id}");
+
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
Le fallback d'affichage du nom (name > discord_global_name > discord_username) ne pouvait jamais aboutir au dernier niveau car discord_username n'était exposé ni par UserResource (show/me) ni par UserController::index (liste users).

Isole aussi les tests sur SQLite en mémoire (phpunit.xml) pour éviter que RefreshDatabase ne touche la base de connexion réelle.