### PR TITLE
Ajoute le compteur global de players online

### DIFF
--- a/app/Actions/UpdateServerStatus.php
+++ b/app/Actions/UpdateServerStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Actions;
+
+use Illuminate\Support\Facades\Cache;
+
+class UpdateServerStatus
+{
+    public function handle(int $playersOnline): void
+    {
+        Cache::put('server_status:players_online', $playersOnline, now()->addSeconds(90));
+    }
+}

--- a/app/Http/Controllers/Api/ServerStatusController.php
+++ b/app/Http/Controllers/Api/ServerStatusController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Actions\UpdateServerStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateServerStatusRequest;
+use App\Http\Resources\ServerStatusResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+
+class ServerStatusController extends Controller
+{
+    public function update(UpdateServerStatusRequest $request, UpdateServerStatus $action): JsonResponse
+    {
+        $action->handle($request->validated('players_online'));
+
+        return response()->json(['success' => true]);
+    }
+
+    public function show(): ServerStatusResource
+    {
+        return new ServerStatusResource(Cache::get('server_status:players_online'));
+    }
+}

--- a/app/Http/Requests/UpdateServerStatusRequest.php
+++ b/app/Http/Requests/UpdateServerStatusRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateServerStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'players_online' => ['required', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Resources/ServerStatusResource.php
+++ b/app/Http/Resources/ServerStatusResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ServerStatusResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'players_online' => $this->resource,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\AnonymousPlayerController;
 use App\Http\Controllers\Api\EventController;
 use App\Http\Controllers\Api\LapTimeController;
+use App\Http\Controllers\Api\ServerStatusController;
 use App\Http\Controllers\Api\TrackController;
 use App\Http\Controllers\Api\UserController;
 use App\Http\Middleware\RoleMiddleware;
@@ -43,5 +44,8 @@ Route::middleware([VerifyApiKey::class])->group(function () {
 
     Route::get('/players', [AnonymousPlayerController::class, 'index']);
     Route::get('/players/{anonymousUser}', [AnonymousPlayerController::class, 'show']);
+
+    Route::post('/server-status', [ServerStatusController::class, 'update']);
+    Route::get('/server-status', [ServerStatusController::class, 'show']);
 
 });

--- a/tests/Feature/ServerStatusTest.php
+++ b/tests/Feature/ServerStatusTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class ServerStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function apiKeyHeader(): array
+    {
+        return ['Authorization' => 'Bearer '.config('custom.api_key')];
+    }
+
+    public function test_post_server_status_with_valid_api_key_returns_success_and_stores_cache(): void
+    {
+        $response = $this->postJson('/api/server-status', ['players_online' => 12], $this->apiKeyHeader());
+
+        $response->assertStatus(200);
+        $response->assertExactJson(['success' => true]);
+        $this->assertEquals(12, Cache::get('server_status:players_online'));
+    }
+
+    public function test_post_server_status_without_api_key_returns_401(): void
+    {
+        $response = $this->postJson('/api/server-status', ['players_online' => 12]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_post_server_status_with_invalid_api_key_returns_401(): void
+    {
+        $response = $this->postJson('/api/server-status', ['players_online' => 12], [
+            'Authorization' => 'Bearer invalid-key',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_post_server_status_without_players_online_returns_422(): void
+    {
+        $response = $this->postJson('/api/server-status', [], $this->apiKeyHeader());
+
+        $response->assertStatus(422);
+    }
+
+    public function test_post_server_status_with_non_numeric_players_online_returns_422(): void
+    {
+        $response = $this->postJson('/api/server-status', ['players_online' => 'abc'], $this->apiKeyHeader());
+
+        $response->assertStatus(422);
+    }
+
+    public function test_post_server_status_with_negative_players_online_returns_422(): void
+    {
+        $response = $this->postJson('/api/server-status', ['players_online' => -1], $this->apiKeyHeader());
+
+        $response->assertStatus(422);
+    }
+
+    public function test_get_server_status_with_cached_value_returns_it(): void
+    {
+        Cache::put('server_status:players_online', 42, now()->addSeconds(90));
+
+        $response = $this->getJson('/api/server-status', $this->apiKeyHeader());
+
+        $response->assertStatus(200);
+        $response->assertExactJson(['data' => ['players_online' => 42]]);
+    }
+
+    public function test_get_server_status_without_api_key_returns_401(): void
+    {
+        $response = $this->getJson('/api/server-status');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_get_server_status_with_empty_cache_returns_null(): void
+    {
+        Cache::forget('server_status:players_online');
+
+        $response = $this->getJson('/api/server-status', $this->apiKeyHeader());
+
+        $response->assertStatus(200);
+        $response->assertExactJson(['data' => ['players_online' => null]]);
+    }
+
+    public function test_get_server_status_with_zero_players_online_returns_zero_distinct_from_null(): void
+    {
+        Cache::put('server_status:players_online', 0, now()->addSeconds(90));
+
+        $response = $this->getJson('/api/server-status', $this->apiKeyHeader());
+
+        $response->assertStatus(200);
+        $response->assertExactJson(['data' => ['players_online' => 0]]);
+    }
+}


### PR DESCRIPTION
live-timing pousse le nombre de joueurs connectés via POST /api/server-status, stocké en cache (90s TTL, pas de nouvelle table). GET /api/server-status expose la valeur (null si expirée) pour le frontend.